### PR TITLE
Fix Windows excutable show white screen only

### DIFF
--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -10,7 +10,7 @@ const ideMenu =  require('./menu')
 let mainWindow
 
 // Create a new BrowserWindow when `app` is ready
-async function createWindow () {
+function createWindow () {
 
   mainWindow = new BrowserWindow({
     // frame: false,
@@ -25,12 +25,11 @@ async function createWindow () {
   if (process.platform === 'darwin') { 
     const image = nativeImage.createFromPath(path.resolve(__dirname, 'build/icon.png'))
     app.dock.setIcon(image) 
-    await systemPreferences.askForMediaAccess('camera');
-  } else {
-    const status = await systemPreferences.getMediaAccessStatus('camera');
-    if(status === 'granted') {
-      alert('App does not have access to the camera');
-    }
+    systemPreferences.askForMediaAccess('camera');
+  } 
+  const status = systemPreferences.getMediaAccessStatus('camera')
+  if(status !== 'granted') {
+    // Log device does not have access to camera
   }
 
   // Load index.html into the new BrowserWindow


### PR DESCRIPTION
## Description

Hotfix for Windows executable white screen issue

## Testing

- Run `npm run install && npm run build` from MacOS
- Copy IDE.0.0.0-win.zip to Windows machine
- Unzip the file
- Double click on IDE.exe file

## Expected Results

- You should be able to see components 

## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
