### PR TITLE
COP-1889 Add store for logging data

### DIFF
--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -12,6 +12,7 @@ const path = require('path');
 
 // Local imports
 const ideMenu = require('./menu');
+const Store = require('./store');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -15,7 +15,7 @@ const ideMenu = require('./menu');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
-let mainWindow;
+let mainWindow, onlineStatusWindow;
 
 // Create a new BrowserWindow when `app` is ready
 function createWindow() {
@@ -97,4 +97,8 @@ ipcMain.on('webCamDevices', (event, list) => {
   }
 
   Menu.setApplicationMenu(ideMenu);
+});
+
+ipcMain.on('online-status-changed', (event, status) => {
+  onlineStatusWindow = status; // eslint-disable-line
 });

--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -12,7 +12,6 @@ const path = require('path');
 
 // Local imports
 const ideMenu = require('./menu');
-const Store = require('./store');
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.

--- a/packages/electron/store.js
+++ b/packages/electron/store.js
@@ -1,0 +1,27 @@
+const electron = require('electron');
+const path = require('path');
+const fs = require('fs');
+
+class Store {
+  constructor(fileName = 'ide-controller') {
+    const userDataPath = (electron.app || electron.remote.app).getPath(
+      'userData'
+    );
+    this.path = path.join(userDataPath, `${fileName}.db`);
+  }
+
+  set(key, value) {
+    fs.appendFile(
+      this.path,
+      `${JSON.stringify({
+        [key]: value,
+        timestamp: Date.now(),
+      })}\n`,
+      function (err) {
+        if (err) throw err;
+      }
+    );
+  }
+}
+
+module.exports = Store;

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -5,6 +5,9 @@ import React, { useState, useEffect } from 'react';
 import DocumentData from './Types/DocumentData';
 import PageBody from './Components/PageBody';
 import { ImageProvider } from './Components/ImageContext';
+import { initOnlineStatus } from './helpers/electron';
+
+initOnlineStatus();
 
 const App = () => {
   const [fullpage, setFullpage] = useState(new Map());

--- a/packages/react/src/helpers/electron.js
+++ b/packages/react/src/helpers/electron.js
@@ -1,0 +1,17 @@
+const electron = window.require('electron');
+const { ipcRenderer } = electron;
+
+export const initOnlineStatus = () => {
+  const updateOnlineStatus = () => {
+    ipcRenderer.send(
+      'online-status-changed',
+      navigator.onLine ? 'online' : 'offline'
+    );
+  };
+
+  window.addEventListener('online', updateOnlineStatus);
+  window.addEventListener('offline', updateOnlineStatus);
+  updateOnlineStatus();
+};
+
+export default {};


### PR DESCRIPTION
## Description
Add store to electron and `updateOnlineStatus` in react to send online/ offline status back to the electron app. The state will determin if we should upload logs file or wait until the device is back online.

## Testing
Import `Store` into main.js and call `set(key, value)` function. Then `onpen ide-controller.db` in `useData` folder. You should see the data recorded in that file.


## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
