### PR TITLE
COP 1977: Build image atom

### DIFF
--- a/packages/react/src/Components/Atoms/Image.jsx
+++ b/packages/react/src/Components/Atoms/Image.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 // Local imports
 import { ImageConsumer } from '../ImageContext';
 import Config from '../Config';
-import '../Controller.css';
+import '../Controller.scss';
 
 const constructImageURL = (base64) => `data:image/jpeg;base64,${base64}`;
 

--- a/packages/react/src/Components/Atoms/Image.jsx
+++ b/packages/react/src/Components/Atoms/Image.jsx
@@ -1,31 +1,20 @@
 // Global imports
+import PropTypes from 'prop-types';
 import React from 'react';
 
 // Local imports
-import { ImageConsumer } from '../ImageContext';
-import Config from '../Config';
 import '../Controller.scss';
 
-const constructImageURL = (base64) => `data:image/jpeg;base64,${base64}`;
-
-const Image = (imageID, imageAlt) => {
+const Image = ({ image, imageAlt }) => {
   return (
-    <ImageConsumer>
-      {(fullPage) => {
-        const datamap = new Map(fullPage);
-        const image = datamap.has(imageID)
-          ? constructImageURL(datamap.get(imageID).image)
-          : Config.blankAvatar;
-        return (
-          <div
-            className="photoContainer--photo medium"
-            alt={imageAlt}
-            style={{ backgroundImage: `url(${image})` }}
-          />
-        );
-      }}
-    </ImageConsumer>
+    <div
+      className="photoContainer--photo medium"
+      alt={imageAlt}
+      style={{ backgroundImage: `url(${image})` }}
+    />
   );
 };
+
+// @todo add prop checks and defaults
 
 export default Image;

--- a/packages/react/src/Components/Atoms/Image.jsx
+++ b/packages/react/src/Components/Atoms/Image.jsx
@@ -15,6 +15,13 @@ const Image = ({ image, imageAlt }) => {
   );
 };
 
-// @todo add prop checks and defaults
+Image.propTypes = {
+  image: PropTypes.string.isRequired,
+  imageAlt: PropTypes.string,
+};
+
+Image.defaultProps = {
+  imageAlt: '',
+};
 
 export default Image;

--- a/packages/react/src/Components/Atoms/Image.jsx
+++ b/packages/react/src/Components/Atoms/Image.jsx
@@ -1,0 +1,31 @@
+// Global imports
+import React from 'react';
+
+// Local imports
+import { ImageConsumer } from '../ImageContext';
+import Config from '../Config';
+import '../Controller.css';
+
+const constructImageURL = (base64) => `data:image/jpeg;base64,${base64}`;
+
+const Image = (imageID, imageAlt) => {
+  return (
+    <ImageConsumer>
+      {(fullPage) => {
+        const datamap = new Map(fullPage);
+        const image = datamap.has(imageID)
+          ? constructImageURL(datamap.get(imageID).image)
+          : Config.blankAvatar;
+        return (
+          <div
+            className="photoContainer--photo medium"
+            alt={imageAlt}
+            style={{ backgroundImage: `url(${image})` }}
+          />
+        );
+      }}
+    </ImageConsumer>
+  );
+};
+
+export default Image;

--- a/packages/react/src/Components/ChipImage.jsx
+++ b/packages/react/src/Components/ChipImage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 // Local imports
 import Image from './Atoms/Image';
-import './Controller.css';
+import './Controller.scss';
 
 const ChipImage = () => {
   return (

--- a/packages/react/src/Components/ChipImage.jsx
+++ b/packages/react/src/Components/ChipImage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 // Local imports
 import { ImageConsumer } from './ImageContext';
+import Image from './Atoms/Image';
 import Config from './Config';
 import './Controller.scss';
 
@@ -16,20 +17,13 @@ const ChipImage = () => {
             if (datamap.has('CD_IMAGEVIS')) {
               const docdata = datamap.get('CD_IMAGEVIS');
               return (
-                <img
-                  src={`data:image/jpeg;base64,${docdata.image}`}
-                  alt="Chip"
-                  className="responsive"
+                <Image
+                  image={`data:image/jpeg;base64,${docdata.image}`}
+                  imageAlt="Chip"
                 />
               );
             }
-            return (
-              <img
-                src={Config.blankAvatar}
-                alt="Place holder"
-                className="responsive"
-              />
-            );
+            return <Image image={Config.blankAvatar} imageAlt="Place holder" />;
           }}
         </ImageConsumer>
       </div>

--- a/packages/react/src/Components/ChipImage.jsx
+++ b/packages/react/src/Components/ChipImage.jsx
@@ -2,36 +2,16 @@
 import React from 'react';
 
 // Local imports
-import { ImageConsumer } from './ImageContext';
-import Config from './Config';
+import Image from './Atoms/Image';
 import './Controller.css';
 
 const ChipImage = () => {
   return (
-    <div className="govuk-grid-column-one-third">
+    <div className="govuk-grid-column-one-third image-padding">
       <div className="photoContainer--photo medium at6">
-        <ImageConsumer>
-          {(fullPage) => {
-            const datamap = new Map(fullPage);
-            if (datamap.has('CD_IMAGEVIS')) {
-              const docdata = datamap.get('CD_IMAGEVIS');
-              return (
-                <img
-                  src={`data:image/jpeg;base64,${docdata.image}`}
-                  alt="Chip"
-                  className="responsive"
-                />
-              );
-            }
-            return (
-              <img
-                src={Config.blankAvatar}
-                alt="Place holder"
-                className="responsive"
-              />
-            );
-          }}
-        </ImageConsumer>
+        <span className="shadow">
+          <Image imageID="CD_SCDG2_PHOTO" imageAlt="Chip" />
+        </span>
       </div>
     </div>
   );

--- a/packages/react/src/Components/ChipImage.jsx
+++ b/packages/react/src/Components/ChipImage.jsx
@@ -2,16 +2,36 @@
 import React from 'react';
 
 // Local imports
-import Image from './Atoms/Image';
+import { ImageConsumer } from './ImageContext';
+import Config from './Config';
 import './Controller.scss';
 
 const ChipImage = () => {
   return (
-    <div className="govuk-grid-column-one-third image-padding">
+    <div className="govuk-grid-column-one-third">
       <div className="photoContainer--photo medium at6">
-        <span className="shadow">
-          <Image imageID="CD_SCDG2_PHOTO" imageAlt="Chip" />
-        </span>
+        <ImageConsumer>
+          {(fullPage) => {
+            const datamap = new Map(fullPage);
+            if (datamap.has('CD_IMAGEVIS')) {
+              const docdata = datamap.get('CD_IMAGEVIS');
+              return (
+                <img
+                  src={`data:image/jpeg;base64,${docdata.image}`}
+                  alt="Chip"
+                  className="responsive"
+                />
+              );
+            }
+            return (
+              <img
+                src={Config.blankAvatar}
+                alt="Place holder"
+                className="responsive"
+              />
+            );
+          }}
+        </ImageConsumer>
       </div>
     </div>
   );

--- a/packages/react/src/Components/Controller.css
+++ b/packages/react/src/Components/Controller.css
@@ -28,3 +28,22 @@
 .govuk-width-container {
   max-width: 95%;
 }
+
+.photoContainer--photo {
+  background-repeat: no-repeat;
+  margin-bottom: 0;
+  height: 450px;
+  width: 100%;
+  background-size: cover;
+  background-position: center 80px;
+  box-shadow: inset 0 0 0 10px #FFF;
+}
+
+.shadow {
+  box-shadow: 0px 2px 6px 2px #bfc1c3;
+  display: block;
+}
+
+.image-padding {
+  padding: 5px;
+}

--- a/packages/react/src/Components/Controller.scss
+++ b/packages/react/src/Components/Controller.scss
@@ -5,15 +5,15 @@
 }
 
 .neutral {
-  color: #505a5f; 
+  color: #505a5f;
 }
 
 .fail {
-  color: #d4351c; 
+  color: #d4351c;
 }
 
 .pass {
-  color: #00703c; 
+  color: #00703c;
 }
 
 .warning {
@@ -29,14 +29,16 @@
   max-width: 95%;
 }
 
-.photoContainer--photo {
-  background-repeat: no-repeat;
-  margin-bottom: 0;
-  height: 450px;
-  width: 100%;
-  background-size: cover;
-  background-position: center 80px;
-  box-shadow: inset 0 0 0 10px #FFF;
+.photoContainer {
+  &--photo {
+    background-repeat: no-repeat;
+    margin-bottom: 0;
+    height: 450px;
+    width: 100%;
+    background-size: cover;
+    background-position: center 80px;
+    box-shadow: inset 0 0 0 10px #fff;
+  }
 }
 
 .shadow {

--- a/packages/react/src/Components/LiveImage.jsx
+++ b/packages/react/src/Components/LiveImage.jsx
@@ -12,7 +12,7 @@ import {
 } from '../helpers/camera';
 import CanvasImage from './Atoms/CanvasImage';
 import CanvasStrokeRect from './Atoms/CanvasStrokeRect';
-import './Controller.css';
+import './Controller.scss';
 import Video from './Video';
 
 const LiveImage = ({ deviceId }) => {

--- a/packages/react/src/Components/ScanImage.jsx
+++ b/packages/react/src/Components/ScanImage.jsx
@@ -2,37 +2,16 @@
 import React from 'react';
 
 // Local imports
-import { ImageConsumer } from './ImageContext';
-import Config from './Config';
+import Image from './Atoms/Image';
 import './Controller.css';
 
 const PhotoPanel = () => {
   return (
-    <div className="govuk-grid-column-one-third">
+    <div className="govuk-grid-column-one-third image-padding">
       <div className="photoContainer--photo medium at6">
-        <ImageConsumer>
-          {(fullPage) => {
-            const datamap = new Map(fullPage);
-
-            if (datamap.has('CD_IMAGEPHOTO')) {
-              const docdata = datamap.get('CD_IMAGEPHOTO');
-              return (
-                <img
-                  src={`data:image/jpeg;base64,${docdata.image}`}
-                  alt="Document scan"
-                  className="responsive"
-                />
-              );
-            }
-            return (
-              <img
-                src={Config.blankAvatar}
-                alt="Place holder"
-                className="responsive"
-              />
-            );
-          }}
-        </ImageConsumer>
+        <span className="shadow">
+          <Image imageID="CD_IMAGEPHOTO" imageAlt="Scan" />
+        </span>
       </div>
     </div>
   );

--- a/packages/react/src/Components/ScanImage.jsx
+++ b/packages/react/src/Components/ScanImage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 // Local imports
 import Image from './Atoms/Image';
-import './Controller.css';
+import './Controller.scss';
 
 const PhotoPanel = () => {
   return (

--- a/packages/react/src/Components/ScanImage.jsx
+++ b/packages/react/src/Components/ScanImage.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 // Local imports
 import { ImageConsumer } from './ImageContext';
+import Image from './Atoms/Image';
 import Config from './Config';
 import './Controller.scss';
 
@@ -17,20 +18,13 @@ const PhotoPanel = () => {
             if (datamap.has('CD_IMAGEPHOTO')) {
               const docdata = datamap.get('CD_IMAGEPHOTO');
               return (
-                <img
-                  src={`data:image/jpeg;base64,${docdata.image}`}
-                  alt="Document scan"
-                  className="responsive"
+                <Image
+                  image={`data:image/jpeg;base64,${docdata.image}`}
+                  imageAlt="Scan"
                 />
               );
             }
-            return (
-              <img
-                src={Config.blankAvatar}
-                alt="Place holder"
-                className="responsive"
-              />
-            );
+            return <Image image={Config.blankAvatar} imageAlt="Place holder" />;
           }}
         </ImageConsumer>
       </div>

--- a/packages/react/src/Components/ScanImage.jsx
+++ b/packages/react/src/Components/ScanImage.jsx
@@ -2,16 +2,37 @@
 import React from 'react';
 
 // Local imports
-import Image from './Atoms/Image';
+import { ImageConsumer } from './ImageContext';
+import Config from './Config';
 import './Controller.scss';
 
 const PhotoPanel = () => {
   return (
-    <div className="govuk-grid-column-one-third image-padding">
+    <div className="govuk-grid-column-one-third">
       <div className="photoContainer--photo medium at6">
-        <span className="shadow">
-          <Image imageID="CD_IMAGEPHOTO" imageAlt="Scan" />
-        </span>
+        <ImageConsumer>
+          {(fullPage) => {
+            const datamap = new Map(fullPage);
+
+            if (datamap.has('CD_IMAGEPHOTO')) {
+              const docdata = datamap.get('CD_IMAGEPHOTO');
+              return (
+                <img
+                  src={`data:image/jpeg;base64,${docdata.image}`}
+                  alt="Document scan"
+                  className="responsive"
+                />
+              );
+            }
+            return (
+              <img
+                src={Config.blankAvatar}
+                alt="Place holder"
+                className="responsive"
+              />
+            );
+          }}
+        </ImageConsumer>
       </div>
     </div>
   );


### PR DESCRIPTION
## Description
The branch updates the display styles of the chip and scan image. Adding a shadow to the canvas and a white boarder to the image. It also reduces the padding between each image so as to increase display size.

## How to test
- Install app and run dev (this will open an electron app window)
- If this page is blank, refresh the page with `cmd + r` (mac) or `ctl + r` (windows)
- 2 blank avatar images and one live webcam image will display in the "Images to compare" tab component. The chip image and scan image should possess the properties described above. 

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
