### PR TITLE
COP 1976: Add Tag atom

### DIFF
--- a/packages/react/src/Components/Atoms/Tag.jsx
+++ b/packages/react/src/Components/Atoms/Tag.jsx
@@ -1,0 +1,19 @@
+// Golbal imports
+import React from 'react';
+import PropTypes from 'prop-types';
+
+// Local imports
+import '../Controller.scss';
+
+const Tag = ({ statusText, status }) => {
+  return (
+    <strong className={`govuk-tag tag-state--${status}`}>{statusText}</strong>
+  );
+};
+
+Tag.propTypes = {
+  status: PropTypes.string.isRequired,
+  statusText: PropTypes.string.isRequired,
+};
+
+export default Tag;

--- a/packages/react/src/Components/Controller.scss
+++ b/packages/react/src/Components/Controller.scss
@@ -20,6 +20,21 @@
   color: #f47738;
 }
 
+.tag-state{
+  &--neutral {
+    background-color: #505a5f;
+  }
+  &--passed {
+    background-color: #00703c;
+  }
+  &--failed {
+    background-color: #d4351c;
+  }
+  &--warning {
+    background-color: #f47738;
+  }
+}
+
 .header-width {
   margin-left: 2.5%;
   margin-right: 2.5%;

--- a/packages/react/src/Components/MatchTable.jsx
+++ b/packages/react/src/Components/MatchTable.jsx
@@ -26,9 +26,21 @@ const MatchTable = () => {
           </tr>
         </thead>
         <tbody className="govuk-table__body">
-          <TableRow rowLabel="Live to chip" status="Pending Document" />
-          <TableRow rowLabel="Live to document" status="Pending Document" />
-          <TableRow rowLabel="Chip to document" status="Pending Document" />
+          <TableRow
+            rowLabel="Live to chip"
+            status="neutral"
+            statusText="No chip"
+          />
+          <TableRow
+            rowLabel="Live to document"
+            status="neutral"
+            statusText="No chip"
+          />
+          <TableRow
+            rowLabel="Chip to document"
+            status="neutral"
+            statusText="No chip"
+          />
         </tbody>
       </table>
     </>

--- a/packages/react/src/Components/ReadTable.jsx
+++ b/packages/react/src/Components/ReadTable.jsx
@@ -25,8 +25,16 @@ const ReadTable = () => {
           </tr>
         </thead>
         <tbody className="govuk-table__body">
-          <TableRow rowLabel="Live to chip" status="Pending Document" />
-          <TableRow rowLabel="Live to document" status="Pending Document" />
+          <TableRow
+            rowLabel="Live to chip"
+            status="neutral"
+            statusText="No chip"
+          />
+          <TableRow
+            rowLabel="Live to document"
+            status="neutral"
+            statusText="No chip"
+          />
         </tbody>
       </table>
     </>

--- a/packages/react/src/Components/TableRow.jsx
+++ b/packages/react/src/Components/TableRow.jsx
@@ -2,7 +2,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const TableRow = ({ rowLabel, status }) => {
+// Local imports
+import './Controller.scss';
+import Tag from './Atoms/Tag';
+
+const TableRow = ({ rowLabel, status, statusText }) => {
   return (
     <tr className="govuk-table__row">
       <th
@@ -12,9 +16,7 @@ const TableRow = ({ rowLabel, status }) => {
         {rowLabel}
       </th>
       <td className="govuk-table__cell govuk-!-width-one-half">
-        <strong className="govuk-tag govuk-tag--passed app-task-list__task-completed govuk-!-font-size-16">
-          {status}
-        </strong>
+        <Tag status={status} statusText={statusText} />
       </td>
     </tr>
   );
@@ -23,6 +25,7 @@ const TableRow = ({ rowLabel, status }) => {
 TableRow.propTypes = {
   rowLabel: PropTypes.string.isRequired,
   status: PropTypes.string.isRequired,
+  statusText: PropTypes.string.isRequired,
 };
 
 export default TableRow;


### PR DESCRIPTION
## Description
This branch atomises the status tag, to be used in Image Comparison and Data Read tables. 

## How to test
- Install app and run dev (this will open an electron app window)
- If this page is blank, refresh the page with cmd + r (mac) or ctl + r (windows)
- The table to the left of the UI should appear as two separate tables.
- Each display tag should be GDS grey with the tex "NO CHIP"

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
