### PR TITLE
COP-2745 Replace JS Map with JS Object

### DIFF
--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -8,14 +8,14 @@ import { Provider } from './Components/Context';
 import { initOnlineStatus } from './helpers/electron';
 
 initOnlineStatus();
+const eventSourceData = {};
 
 const App = () => {
-  const [context, setContext] = useState(new Map());
+  const [context, setContext] = useState(eventSourceData);
 
   // Doc reader
   useEffect(() => {
     const events = new EventSource('http://localhost:8080/reader/data');
-
     events.addEventListener('data', (e) => {
       const messageData = JSON.parse(e.data);
       const datatype = messageData.dataType;
@@ -24,17 +24,17 @@ const App = () => {
         messageData.codelineData,
         messageData.image
       );
-      context.set(datatype, datadata);
+      eventSourceData[datatype] = datadata;
     });
 
     events.addEventListener('event', (e) => {
       const messageData = JSON.parse(e.data);
       if (messageData.event === 'START_OF_DOCUMENT_DATA') {
-        setContext(new Map());
+        setContext({});
       }
 
       if (messageData.event === 'END_OF_DOCUMENT_DATA') {
-        setContext(context);
+        setContext({ ...eventSourceData });
       }
     });
   }, [context]);

--- a/packages/react/src/Components/Context/index.jsx
+++ b/packages/react/src/Components/Context/index.jsx
@@ -8,7 +8,7 @@ const { Consumer } = Context;
 
 const withContext = (Component) => (props) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
-  <Consumer>{(context) => <Component {...props} context={context} />}</Consumer>
+  <Consumer>{(context) => <Component {...props} value={context} />}</Consumer>
 );
 
 export { Provider, Consumer, withContext };

--- a/packages/react/src/Components/ImagePanel.jsx
+++ b/packages/react/src/Components/ImagePanel.jsx
@@ -31,7 +31,7 @@ const ImagePanel = ({ isActive, value }) => {
 
   const makeDocumentImage = (key) => {
     const image =
-      value.context.[key] &&
+      value.context[key] &&
       `data:image/jpeg;base64,${value.context[key].image}`;
     return (
       <DocumentImage image={image || Config.blankAvatar} imageAlt="Chip" />
@@ -64,6 +64,14 @@ const ImagePanel = ({ isActive, value }) => {
 
 ImagePanel.propTypes = {
   isActive: PropTypes.bool.isRequired,
+  value: PropTypes.shape({
+    context: PropTypes.shape({}),
+    setContext: PropTypes.func,
+  }),
+};
+
+ImagePanel.defaultProps = {
+  value: {},
 };
 
 export default withContext(ImagePanel);

--- a/packages/react/src/Components/ImagePanel.jsx
+++ b/packages/react/src/Components/ImagePanel.jsx
@@ -14,7 +14,7 @@ import PhotoHeaders from './PhotoHeaders';
 const electron = window.require('electron');
 const { ipcRenderer } = electron;
 
-const constructImageURL = (base64) => `data:image/jpeg;base64,${base64}`;
+const constructImageURL = (encoding) => `data:image/jpeg;base64,${encoding}`;
 
 const ImagePanel = ({ isActive, value }) => {
   const [restartCam, setRestartCam] = useState(true);
@@ -31,20 +31,11 @@ const ImagePanel = ({ isActive, value }) => {
     });
   });
 
-  const fun = () => {
-    const { context } = value;
-    const chipImage = context.has('CD_SCDG2_PHOTO')
-      ? constructImageURL(context.get('CD_SCDG2_PHOTO').image)
+  const makeDocumentImage = (key) => {
+    const image = value.context.has(key)
+      ? constructImageURL(value.context.get(key).image)
       : Config.blankAvatar;
-    const scanImage = context.has('CD_IMAGEPHOTO')
-      ? constructImageURL(context.get('CD_IMAGEPHOTO').image)
-      : Config.blankAvatar;
-    return (
-      <>
-        <DocumentImage image={chipImage} imageAlt="Chip" />
-        <DocumentImage image={scanImage} imageAlt="Scan" />
-      </>
-    );
+    return <DocumentImage image={image} imageAlt="Chip" />;
   };
 
   return (
@@ -62,7 +53,8 @@ const ImagePanel = ({ isActive, value }) => {
       </Row>
       <PhotoHeaders />
       <Row>
-        {fun()}
+        {makeDocumentImage('CD_SCDG2_PHOTO')}
+        {makeDocumentImage('CD_IMAGEPHOTO')}
         {restartCam && <LiveImage cameraDeviceId={cameraDeviceId} />}
         <Button onClick={restartLiveImage}>Retake Camera Image</Button>
       </Row>

--- a/packages/react/src/Components/ImagePanel.jsx
+++ b/packages/react/src/Components/ImagePanel.jsx
@@ -6,7 +6,7 @@ import React, { useEffect, useState } from 'react';
 import Button from './Atoms/Button';
 import Config from './Config';
 import DocumentImage from './DocumentImage';
-import { Consumer } from './Context';
+import { withContext } from './Context';
 import LiveImage from './LiveImage';
 import { Row } from './Layout';
 import PhotoHeaders from './PhotoHeaders';
@@ -16,7 +16,7 @@ const { ipcRenderer } = electron;
 
 const constructImageURL = (base64) => `data:image/jpeg;base64,${base64}`;
 
-const ImagePanel = ({ isActive }) => {
+const ImagePanel = ({ isActive, value }) => {
   const [restartCam, setRestartCam] = useState(true);
   const [cameraDeviceId, setCameraDeviceId] = useState();
   const restartLiveImage = () => {
@@ -30,6 +30,22 @@ const ImagePanel = ({ isActive }) => {
       restartLiveImage();
     });
   });
+
+  const fun = () => {
+    const { context } = value;
+    const chipImage = context.has('CD_SCDG2_PHOTO')
+      ? constructImageURL(context.get('CD_SCDG2_PHOTO').image)
+      : Config.blankAvatar;
+    const scanImage = context.has('CD_IMAGEPHOTO')
+      ? constructImageURL(context.get('CD_IMAGEPHOTO').image)
+      : Config.blankAvatar;
+    return (
+      <>
+        <DocumentImage image={chipImage} imageAlt="Chip" />
+        <DocumentImage image={scanImage} imageAlt="Scan" />
+      </>
+    );
+  };
 
   return (
     <div
@@ -46,23 +62,7 @@ const ImagePanel = ({ isActive }) => {
       </Row>
       <PhotoHeaders />
       <Row>
-        <Consumer>
-          {({ context }) => {
-            const docData = new Map(context);
-            const chipImage = docData.has('CD_SCDG2_PHOTO')
-              ? constructImageURL(docData.get('CD_SCDG2_PHOTO').image)
-              : Config.blankAvatar;
-            const scanImage = docData.has('CD_IMAGEPHOTO')
-              ? constructImageURL(docData.get('CD_IMAGEPHOTO').image)
-              : Config.blankAvatar;
-            return (
-              <>
-                <DocumentImage image={chipImage} imageAlt="Chip" />
-                <DocumentImage image={scanImage} imageAlt="Scan" />
-              </>
-            );
-          }}
-        </Consumer>
+        {fun()}
         {restartCam && <LiveImage cameraDeviceId={cameraDeviceId} />}
         <Button onClick={restartLiveImage}>Retake Camera Image</Button>
       </Row>
@@ -74,4 +74,4 @@ ImagePanel.propTypes = {
   isActive: PropTypes.bool.isRequired,
 };
 
-export default ImagePanel;
+export default withContext(ImagePanel);

--- a/packages/react/src/Components/ImagePanel.jsx
+++ b/packages/react/src/Components/ImagePanel.jsx
@@ -14,8 +14,6 @@ import PhotoHeaders from './PhotoHeaders';
 const electron = window.require('electron');
 const { ipcRenderer } = electron;
 
-const constructImageURL = (encoding) => `data:image/jpeg;base64,${encoding}`;
-
 const ImagePanel = ({ isActive, value }) => {
   const [restartCam, setRestartCam] = useState(true);
   const [cameraDeviceId, setCameraDeviceId] = useState();
@@ -32,10 +30,12 @@ const ImagePanel = ({ isActive, value }) => {
   });
 
   const makeDocumentImage = (key) => {
-    const image = value.context.has(key)
-      ? constructImageURL(value.context.get(key).image)
-      : Config.blankAvatar;
-    return <DocumentImage image={image} imageAlt="Chip" />;
+    const image =
+      value.context.has(key) &&
+      `data:image/jpeg;base64,${value.context.get(key).image}`;
+    return (
+      <DocumentImage image={image || Config.blankAvatar} imageAlt="Chip" />
+    );
   };
 
   return (

--- a/packages/react/src/Components/ImagePanel.jsx
+++ b/packages/react/src/Components/ImagePanel.jsx
@@ -31,8 +31,8 @@ const ImagePanel = ({ isActive, value }) => {
 
   const makeDocumentImage = (key) => {
     const image =
-      value.context.has(key) &&
-      `data:image/jpeg;base64,${value.context.get(key).image}`;
+      value.context.[key] &&
+      `data:image/jpeg;base64,${value.context[key].image}`;
     return (
       <DocumentImage image={image || Config.blankAvatar} imageAlt="Chip" />
     );

--- a/packages/react/src/Components/LiveImage.jsx
+++ b/packages/react/src/Components/LiveImage.jsx
@@ -18,7 +18,7 @@ import ImageCard from './Molecules/ImageCard';
 import { withContext } from './Context';
 import Video from './Video';
 
-const LiveImage = ({ deviceId, context }) => {
+const LiveImage = ({ deviceId, value }) => {
   const canvasRef = useRef('canvas');
   const guidCanvasRef = useRef('guidCanvas');
   const videoRef = useRef();
@@ -43,7 +43,7 @@ const LiveImage = ({ deviceId, context }) => {
     if (isBelowThreshold(keypoints)) {
       estimate(net);
     } else {
-      context.context.set('image', videoRef.current);
+      value.context.set('image', videoRef.current);
       videoRef.current.pause();
       setShowCanvas(true);
       setShowVideo(false);

--- a/packages/react/src/Components/LiveImage.jsx
+++ b/packages/react/src/Components/LiveImage.jsx
@@ -115,14 +115,13 @@ export default withContext(LiveImage);
 
 LiveImage.propTypes = {
   deviceId: PropTypes.string,
-  context: PropTypes.shape({
-    context: PropTypes.shape({
-      set: PropTypes.func,
-    }),
+  value: PropTypes.shape({
+    context: PropTypes.shape({}),
+    setContext: PropTypes.func,
   }),
 };
 
 LiveImage.defaultProps = {
   deviceId: null,
-  context: {},
+  value: {},
 };

--- a/packages/react/src/Components/LiveImage.jsx
+++ b/packages/react/src/Components/LiveImage.jsx
@@ -43,7 +43,11 @@ const LiveImage = ({ deviceId, value }) => {
     if (isBelowThreshold(keypoints)) {
       estimate(net);
     } else {
-      value.context.set('image', videoRef.current);
+      const { context, setContext } = value;
+      setContext({
+        imgae: videoRef.current,
+        ...context,
+      });
       videoRef.current.pause();
       setShowCanvas(true);
       setShowVideo(false);


### PR DESCRIPTION
## Description

In this PR I am replacing JS Map with JS Object. The reason for is when using `setState` it come with `set` function. The `set` function require new object to update the sate. Destructuring JS Object is easier than JS Map.

## Testing
This PR does not change any functionality. To test you should build and run without any error, layout or functional change.

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
