### PR TITLE
COP 1977: Split Match State component

### DIFF
--- a/packages/react/src/Components/MatchState.jsx
+++ b/packages/react/src/Components/MatchState.jsx
@@ -1,13 +1,15 @@
 // Global imports
 import React from 'react';
 
-const MatchValue = () => {
+// Local imports
+
+const MatchState = () => {
   return (
     <div className="govuk-grid-column-one-half">
-      <span className="govuk-caption-m">Result</span>
+      <span className="govuk-caption-m">Image likeness</span>
       <h1 className="govuk-heading-xl govuk-!-font-size-48 neutral">No Data</h1>
     </div>
   );
 };
 
-export default MatchValue;
+export default MatchState;

--- a/packages/react/src/Components/PageBody.jsx
+++ b/packages/react/src/Components/PageBody.jsx
@@ -7,6 +7,8 @@ import Header from './Header';
 import InfoTable from './InfoTable';
 import InfoTabs from './InfoTabs';
 import MatchValue from './MatchValue';
+import MatchState from './MatchState';
+import { Row } from './Layout';
 
 const PageBody = () => {
   return (
@@ -15,7 +17,10 @@ const PageBody = () => {
       {/* <div className="govuk-width-container body-width"> */}
       <main className="govuk-main-wrapper" role="main">
         <div className="govuk-grid-column-one-quarter-from-desktop">
-          <MatchValue />
+          <Row>
+            <MatchState />
+            <MatchValue />
+          </Row>
           <InfoTable />
           <p>
             This data will automatically be deleted when another document is


### PR DESCRIPTION
## Description
This branch splits the Match State component into Image likeness and Result. 

## To test
- Install app and run dev (this will open an electron app window)
- If this page is blank, refresh the page with cmd + r (mac) or ctl + r (windows)
- The match value component on the left side of the screen now comprises two separate components, "Image likeness" and "Result".

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
