### PR TITLE
COP-2745 Send images to backend

### DIFF
--- a/packages/idemia-reader-mock/image-match-response.json
+++ b/packages/idemia-reader-mock/image-match-response.json
@@ -1,1 +1,22 @@
-{"action":"Match","images":[{"name":"Image 1","height":450,"width":800,"resolution":0.0,"quality":100,"colour":"RGB24"},{"name":"Image 2","height":450,"width":800,"resolution":0.0,"quality":100,"colour":"RGB24"}],"score":7477}
+{
+  "action": "Match",
+  "images": [
+    {
+      "name": "Image 1",
+      "height": 450,
+      "width": 800,
+      "resolution": 0.0,
+      "quality": 100,
+      "colour": "RGB24"
+    },
+    {
+      "name": "Image 2",
+      "height": 450,
+      "width": 800,
+      "resolution": 0.0,
+      "quality": 100,
+      "colour": "RGB24"
+    }
+  ],
+  "score": 7000
+}

--- a/packages/idemia-reader-mock/index.js
+++ b/packages/idemia-reader-mock/index.js
@@ -3,6 +3,10 @@ const idemiaResponse = require('./image-match-response.json');
 const readerResponse = require('./reader-response');
 
 const idemiaServer = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+	res.setHeader('Access-Control-Request-Method', '*');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'PUT, POST, GET, DELETE, OPTIONS');
   if (req.method === 'POST' && req.url === '/image/match') {
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(idemiaResponse));
@@ -16,8 +20,8 @@ idemiaServer.listen(8081);
 const readerServer = http.createServer((req, res) => {
   res.setHeader('Access-Control-Allow-Origin', '*');
 	res.setHeader('Access-Control-Request-Method', '*');
-	res.setHeader('Access-Control-Allow-Methods', 'OPTIONS, GET');
-	res.setHeader('Access-Control-Allow-Headers', '*');
+  res.setHeader('Access-Control-Allow-Headers', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'PUT, POST, GET, DELETE, OPTIONS');
   if (req.url === '/reader/data') {
     res.writeHead(200, {
       'Content-Type': 'text/event-stream',

--- a/packages/idemia-reader-mock/index.js
+++ b/packages/idemia-reader-mock/index.js
@@ -7,7 +7,8 @@ const idemiaServer = http.createServer((req, res) => {
 	res.setHeader('Access-Control-Request-Method', '*');
   res.setHeader('Access-Control-Allow-Headers', '*');
   res.setHeader('Access-Control-Allow-Methods', 'PUT, POST, GET, DELETE, OPTIONS');
-  if (req.method === 'POST' && req.url === '/image/match') {
+  console.log('here')
+  if (['POST', 'OPTIONS'].includes(req.method) && req.url === '/image/match') {
     res.setHeader('Content-Type', 'application/json');
     res.end(JSON.stringify(idemiaResponse));
   }

--- a/packages/react/.eslintrc.js
+++ b/packages/react/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   plugins: ['react', 'prettier'],
   ignorePatterns: ['/node_modules', '/src/__tests__/__snapshots__', '/build'],
   rules: {
+    "react/destructuring-assignment": "off",
     "jsx-a11y/media-has-caption": "off",
     quotes: ['error', 'single'],
     eqeqeq: 'error',

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -40,10 +40,11 @@ const App = () => {
   }, [context]);
 
   useEffect(() => {
-    if (context.image === undefined) return;
+    const { eventSourceData: evenDdata, image } = context;
+    if (!evenDdata?.CD_SCDG2_PHOTO?.image || !image) return;
     post('http://localhost:8081/image/match', {
       image: context.image,
-      image2: `data:image/jpeg;base64,${context.eventSourceData.CD_SCDG2_PHOTO.image}`,
+      image2: `data:image/jpeg;base64,${evenDdata.CD_SCDG2_PHOTO.image}`,
     })
       .then((res) => {
         setContext({
@@ -57,7 +58,7 @@ const App = () => {
           match: { score: 0 },
         })
       );
-  }, [context.image]);
+  }, [context.image, context.eventSourceData]);
 
   return (
     <Provider

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect } from 'react';
 import Index from './Components/Pages';
 import { Provider } from './Components/Context';
 import { initOnlineStatus } from './helpers/electron';
+import { post } from './helpers/common';
 
 initOnlineStatus();
 const eventSourceData = {};
@@ -36,6 +37,18 @@ const App = () => {
         setContext({ ...eventSourceData });
       }
     });
+
+    if (context.image) {
+      post('http://localhost:8081/image/match', {
+        image: context.image,
+        image2: context.image,
+      }).then((res) => {
+        setContext({
+          match: res,
+          ...context,
+        });
+      });
+    }
   }, [context]);
 
   return (

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -11,7 +11,7 @@ initOnlineStatus();
 const eventSourceData = {};
 
 const App = () => {
-  const [context, setContext] = useState(eventSourceData);
+  const [context, setContext] = useState({ eventSourceData });
 
   // Doc reader
   useEffect(() => {
@@ -34,22 +34,30 @@ const App = () => {
       }
 
       if (messageData.event === 'END_OF_DOCUMENT_DATA') {
-        setContext({ ...eventSourceData });
+        setContext({ ...context, eventSourceData });
       }
     });
-
-    if (context.image) {
-      post('http://localhost:8081/image/match', {
-        image: context.image,
-        image2: context.image,
-      }).then((res) => {
-        setContext({
-          match: res,
-          ...context,
-        });
-      });
-    }
   }, [context]);
+
+  useEffect(() => {
+    if (context.image === undefined) return;
+    post('http://localhost:8081/image/match', {
+      image: context.image,
+      image2: `data:image/jpeg;base64,${context.eventSourceData.CD_SCDG2_PHOTO.image}`,
+    })
+      .then((res) => {
+        setContext({
+          ...context,
+          match: JSON.parse(res),
+        });
+      })
+      .catch(() =>
+        setContext({
+          ...context,
+          match: { score: 0 },
+        })
+      );
+  }, [context.image]);
 
   return (
     <Provider

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -42,10 +42,6 @@ const App = () => {
   useEffect(() => {
     const { eventSourceData: evenDdata, image } = context;
     if (!evenDdata?.CD_SCDG2_PHOTO?.image || !image) return;
-    console.log({
-      image: image.replace('data:image/jpeg;base64,', ''),
-      image2: evenDdata.CD_SCDG2_PHOTO.image,
-    });
     post('http://localhost:8081/image/match', {
       image: image.replace('data:image/jpeg;base64,', ''),
       image2: evenDdata.CD_SCDG2_PHOTO.image,

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -42,9 +42,13 @@ const App = () => {
   useEffect(() => {
     const { eventSourceData: evenDdata, image } = context;
     if (!evenDdata?.CD_SCDG2_PHOTO?.image || !image) return;
+    console.log({
+      image: image.replace('data:image/jpeg;base64,', ''),
+      image2: evenDdata.CD_SCDG2_PHOTO.image,
+    });
     post('http://localhost:8081/image/match', {
-      image: context.image,
-      image2: `data:image/jpeg;base64,${evenDdata.CD_SCDG2_PHOTO.image}`,
+      image: image.replace('data:image/jpeg;base64,', ''),
+      image2: evenDdata.CD_SCDG2_PHOTO.image,
     })
       .then((res) => {
         setContext({

--- a/packages/react/src/Components/Molecules/ImagePanel.jsx
+++ b/packages/react/src/Components/Molecules/ImagePanel.jsx
@@ -14,8 +14,7 @@ import ImageCard from './ImageCard';
 const electron = window.require('electron');
 const { ipcRenderer } = electron;
 
-const makeImageCard = (key, { context }) => {
-  const { eventSourceData } = context;
+const makeImageCard = (key, { eventSourceData }) => {
   const image =
     eventSourceData &&
     eventSourceData[key] &&
@@ -24,6 +23,7 @@ const makeImageCard = (key, { context }) => {
 };
 
 const ImagePanel = ({ isActive, value }) => {
+  const { context, setContext } = value;
   const [liveImageKey, setLiveImageKey] = useState(
     `liveImageKey-${Date.now()}`
   );
@@ -33,6 +33,7 @@ const ImagePanel = ({ isActive, value }) => {
     setCanRetakeImage(false);
     setLiveImageKey(`liveImageKey-${Date.now()}`);
     setTimeout(() => setCanRetakeImage(true), 1000);
+    setContext({ ...context });
   };
 
   useEffect(() => {
@@ -58,10 +59,10 @@ const ImagePanel = ({ isActive, value }) => {
       <PhotoHeaders />
       <Row>
         <Column size="one-third" className="padding-5">
-          {makeImageCard('CD_SCDG2_PHOTO', value)}
+          {makeImageCard('CD_SCDG2_PHOTO', context)}
         </Column>
         <Column size="one-third" className="padding-5">
-          {makeImageCard('CD_IMAGEPHOTO', value)}
+          {makeImageCard('CD_IMAGEPHOTO', context)}
         </Column>
         {/*
           The reason why we have useMemo here is because LiveImage is computationally expensive.

--- a/packages/react/src/Components/Molecules/ImagePanel.jsx
+++ b/packages/react/src/Components/Molecules/ImagePanel.jsx
@@ -15,7 +15,11 @@ const electron = window.require('electron');
 const { ipcRenderer } = electron;
 
 const makeImageCard = (key, { context }) => {
-  const image = context[key] && `data:image/jpeg;base64,${context[key].image}`;
+  const { eventSourceData } = context;
+  const image =
+    eventSourceData &&
+    eventSourceData[key] &&
+    `data:image/jpeg;base64,${eventSourceData[key].image}`;
   return <ImageCard image={image || blankAvatar} imageAlt={key} />;
 };
 

--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -29,7 +29,7 @@ const LiveImage = ({ cameraId, value }) => {
     );
     setSourceImageOptions(croppedImageCoordination);
     if (isBelowThreshold()) {
-      setTimeout(() => estimate(), 250);
+      setTimeout(() => estimate(), 100);
     } else {
       const { context, setContext } = value;
       videoRef.current.pause();

--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -29,7 +29,7 @@ const LiveImage = ({ cameraId, value }) => {
     );
     setSourceImageOptions(croppedImageCoordination);
     if (isBelowThreshold()) {
-      setTimeout(() => estimate(), 100);
+      setTimeout(() => estimate(), 50);
     } else {
       const { context, setContext } = value;
       videoRef.current.pause();

--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -32,13 +32,13 @@ const LiveImage = ({ cameraId, value }) => {
       setTimeout(() => estimate(), 250);
     } else {
       const { context, setContext } = value;
-      setContext({
-        imgae: videoRef.current,
-        ...context,
-      });
       videoRef.current.pause();
       setShowCanvas(true);
       setShowVideo(false);
+      setContext({
+        image: canvasRef.current.toDataURL('image/jpeg'),
+        ...context,
+      });
     }
   };
 

--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -36,8 +36,8 @@ const LiveImage = ({ cameraId, value }) => {
       setShowCanvas(true);
       setShowVideo(false);
       setContext({
-        image: canvasRef.current.toDataURL('image/jpeg'),
         ...context,
+        image: canvasRef.current.toDataURL('image/jpeg'),
       });
     }
   };

--- a/packages/react/src/Components/Molecules/MatchValue.jsx
+++ b/packages/react/src/Components/Molecules/MatchValue.jsx
@@ -1,11 +1,51 @@
 // Global imports
+import PropTypes from 'prop-types';
 import React from 'react';
 
-const MatchValue = () => (
-  <>
-    <span className="govuk-caption-m">Facial likeness between images</span>
-    <h1 className="govuk-heading-xl govuk-!-font-size-48 fail">READY</h1>
-  </>
-);
+// Local imports
+import { withContext } from '../Context';
 
-export default MatchValue;
+const MatchValue = ({ value }) => {
+  const { match } = value.context;
+  const percentage = (score) => Math.round((score / 7480) * 100);
+  const headerStateClass = ({ score } = {}) => {
+    if (percentage(score) >= 80) return 'pass';
+    if (percentage(score) < 80) return 'fail';
+
+    return '';
+  };
+  const headerText = ({ score } = {}) => {
+    if (score === undefined) return 'Ready';
+    if (typeof score === 'number') return `${percentage(score)}%`;
+
+    return '';
+  };
+
+  return (
+    <>
+      <span className="govuk-caption-m">Facial likeness between images</span>
+      <h1
+        className={`govuk-heading-xl govuk-!-font-size-48 ${headerStateClass(
+          match
+        )}`}
+      >
+        {headerText(match)}
+      </h1>
+    </>
+  );
+};
+
+MatchValue.propTypes = {
+  value: PropTypes.shape({
+    context: PropTypes.shape({
+      match: PropTypes.shape({}),
+    }),
+    setContext: PropTypes.func,
+  }),
+};
+
+MatchValue.defaultProps = {
+  value: { match: { score: 0 } },
+};
+
+export default withContext(MatchValue);

--- a/packages/react/src/Components/Molecules/MatchValue.jsx
+++ b/packages/react/src/Components/Molecules/MatchValue.jsx
@@ -7,7 +7,7 @@ import { withContext } from '../Context';
 
 const MatchValue = ({ value }) => {
   const { match } = value.context;
-  const percentage = (score) => Math.round((score / 7480) * 100);
+  const percentage = (score) => Math.round((score / 8000) * 100);
   const headerStateClass = ({ score } = {}) => {
     if (percentage(score) >= 80) return 'pass';
     if (percentage(score) < 80) return 'fail';

--- a/packages/react/src/helpers/common.js
+++ b/packages/react/src/helpers/common.js
@@ -8,6 +8,7 @@ export const post = (url, data) =>
   fetch(url, {
     method: 'POST',
     body: JSON.stringify(data),
+    headers: { 'Content-Type': 'application/json' },
   }).then((response) => response.text());
 
 export default {};

--- a/packages/react/src/helpers/common.js
+++ b/packages/react/src/helpers/common.js
@@ -4,4 +4,10 @@ export const isEmpty = (object) => {
   return Object.keys(object).length === 0 && object.constructor === Object;
 };
 
+export const post = (url, data) =>
+  fetch(url, {
+    method: 'POST',
+    body: JSON.stringify(data),
+  }).then((response) => response.text());
+
 export default {};


### PR DESCRIPTION
## Description

In this PR
- Add live photo to context
- When chip or live photo is updated send both to backend

## Testing

Part 1
- `npm i && npm run dev`
- Scan document
- Allow live image to take photo
- The score should be updated. If there is no connection the score should be 0
- If you visit the netwrok tab from dev tool you should be able to see new POST request sent to `localhost:8081`

Part 2
- If you click on retake image
- After the photo is taken
- The score should be updated

Part 3
- If you rescan the document
- The score might not be updated if you scan the same document
- New request to `localhost:8081` should be made

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
