### PR TITLE
COP 2433: Add tag update functionality to Image comparison table

### DIFF
--- a/packages/react/src/Components/Molecules/ImageComparisonsTable.jsx
+++ b/packages/react/src/Components/Molecules/ImageComparisonsTable.jsx
@@ -1,31 +1,80 @@
 // Global imports
+import PropTypes from 'prop-types';
 import React from 'react';
 
 // Local imports
 import TableRow from './TableRow';
+import { withContext } from '../Context';
 
-const ImageComparisonsTable = () => {
+const calculatePercentage = (score) => (score / 8000) * 100;
+
+const resultText = (score) => {
+  const percent = calculatePercentage(score);
+  if (percent < 45 && percent > 0) {
+    return 'FAIL';
+  }
+  if (percent === 0) {
+    return 'No Data';
+  }
+  if (percent >= 45) {
+    return 'PASS';
+  }
+  return 'No Data';
+};
+
+const resultClassName = (score) => {
+  const percent = calculatePercentage(score);
+  if (percent < 45 && percent > 0) {
+    return 'fail';
+  }
+  if (percent === 0) {
+    return 'warning';
+  }
+  if (percent >= 45) {
+    return 'passed';
+  }
+  return 'neutral';
+};
+
+const ImageComparisonsTable = ({ value }) => {
+  const { liveBioScore, bioChipScore, liveChipScore } =
+    value.context?.match || {};
+
   return (
     <table className="govuk-table">
       <caption className="govuk-table__caption">Image comparisons</caption>
       <tbody className="govuk-table__body">
         <TableRow
           rowLabel="Live to chip"
-          tagStatus="neutral"
-          tagText="No Data"
+          tagStatus={resultClassName(liveChipScore)}
+          tagText={resultText(liveChipScore)}
         />
         <TableRow
           rowLabel="Live to document"
-          tagStatus="neutral"
-          tagText="No Data"
+          tagStatus={resultClassName(liveBioScore)}
+          tagText={resultText(liveBioScore)}
         />
         <TableRow
           rowLabel="Chip to document"
-          tagStatus="neutral"
-          tagText="No Data"
+          tagStatus={resultClassName(bioChipScore)}
+          tagText={resultText(bioChipScore)}
         />
       </tbody>
     </table>
   );
 };
-export default ImageComparisonsTable;
+
+ImageComparisonsTable.propTypes = {
+  value: PropTypes.shape({
+    context: PropTypes.shape({
+      match: PropTypes.shape({}),
+    }),
+    setContext: PropTypes.func,
+  }),
+};
+
+ImageComparisonsTable.defaultProps = {
+  value: {},
+};
+
+export default withContext(ImageComparisonsTable);

--- a/packages/react/src/Components/Style/global.scss
+++ b/packages/react/src/Components/Style/global.scss
@@ -52,7 +52,7 @@ code {
     height: 450px;
     width: 100%;
     background-size: cover;
-    background-position: center 80px;
+    background-position: center;
     box-shadow: inset 0 0 0 10px #fff;
   }
 }


### PR DESCRIPTION
## Description
This branch allows the tags in the Image comparison table to update as scores are returned from the matching software. 

## To test
- Install app and run dev (this will open an electron app window)
- If this page is blank, refresh the page with cmd + r (mac) or ctl + r (windows)
- Once the live image has been captured, the mock will return match result. 
- The image comparison table tags (left side of UI) will update from "No Data" with a grey background, to "Pass" with a green background. 

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
