### PR TITLE
COP-3063 Add more logs

### DIFF
--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -9,6 +9,7 @@ const {
   systemPreferences,
 } = require('electron');
 const path = require('path');
+const os = require('os');
 
 // Local imports
 const ideMenu = require('./menu');
@@ -125,3 +126,4 @@ process.on('warning', (warning) => {
   userStore.set('WARNING', { warning });
 });
 userStore.set('ApplicationStart', 'Success');
+userStore.set('networkInterfaces', os.networkInterfaces());

--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -113,3 +113,15 @@ ipcMain.handle('addToStore', (event, key, value) => {
     userStore.set('ERROR', 'CAN NOT LOG');
   }
 });
+
+process.on('exit', (code) => {
+  userStore.set('ApplicationExit', 'Process exit event');
+});
+
+process.on('uncaughtException', (err, origin) => {
+  userStore.set('ERROR', { error: err, origin: origin });
+});
+process.on('warning', (warning) => {
+  userStore.set('WARNING', { warning });
+});
+userStore.set('ApplicationStart', 'Success');

--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -110,5 +110,6 @@ ipcMain.handle('addToStore', (event, key, value) => {
     userStore.set(key, value);
   } catch (e) {
     userStore.set({ error: e });
+    userStore.set('ERROR', 'CAN NOT LOG');
   }
 });

--- a/packages/electron/store.js
+++ b/packages/electron/store.js
@@ -14,7 +14,7 @@ class Store {
     fs.appendFile(
       this.path,
       `${JSON.stringify({
-        [key]: JSON.stringify(value),
+        [key]: typeof value === 'object' ? JSON.stringify(value) : value,
         timestamp: Date.now(),
       })}\n`,
       function (err) {

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -37,11 +37,13 @@ const App = () => {
         codelineData: messageData.codelineData,
         image: messageData.image,
       };
+      sendToElectronStore(eventSourceData[datatype], datadata);
       eventSourceData[datatype] = datadata;
     });
 
     events.addEventListener('event', (e) => {
       const messageData = JSON.parse(e.data);
+      sendToElectronStore(messageData.event, messageData);
       if (messageData.event === START_OF_DOCUMENT_DATA) {
         setEventSourceContext({ eventSourceEvent: START_OF_DOCUMENT_DATA });
       }
@@ -63,6 +65,7 @@ const App = () => {
 
     events.addEventListener('status', (e) => {
       const messageData = JSON.parse(e.data);
+      sendToElectronStore('deviceStatus', messageData);
       setStatusContext({
         ...messageData,
       });

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -16,6 +16,7 @@ import {
 import { initOnlineStatus } from './helpers/electron';
 import { post } from './helpers/common';
 import { sendToElectronStore } from './helpers/ipcMainEvents';
+import './helpers/globalError';
 
 initOnlineStatus();
 const eventSourceData = {};

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -14,7 +14,7 @@ import {
   START_OF_DOCUMENT_DATA,
 } from './config/EventSource';
 import { initOnlineStatus } from './helpers/electron';
-import { post } from './helpers/common';
+import { post, generateUUID } from './helpers/common';
 import { sendToElectronStore } from './helpers/ipcMainEvents';
 import './helpers/globalError';
 
@@ -46,6 +46,7 @@ const App = () => {
       const messageData = JSON.parse(e.data);
       sendToElectronStore(messageData.event, messageData);
       if (messageData.event === START_OF_DOCUMENT_DATA) {
+        sendToElectronStore('uuid', generateUUID());
         setEventSourceContext({ eventSourceEvent: START_OF_DOCUMENT_DATA });
       }
 

--- a/packages/react/src/Components/Molecules/ImagePanel.jsx
+++ b/packages/react/src/Components/Molecules/ImagePanel.jsx
@@ -10,6 +10,7 @@ import { Column, Row } from '../Layout';
 import ImageCard from './ImageCard';
 import LiveImage from './LiveImage';
 import PhotoHeaders from './PhotoHeaders';
+import { sendToElectronStore } from '../../helpers/ipcMainEvents';
 
 const electron = window.require('electron');
 const { ipcRenderer } = electron;
@@ -32,6 +33,7 @@ const ImagePanel = ({ isActive }) => {
     setCanRetakeImage(false);
     setLiveImageKey(`liveImageKey-${Date.now()}`);
     setTimeout(() => setCanRetakeImage(true), 1000);
+    sendToElectronStore('Livephoto', 'Retake Camera Image');
   };
 
   useEffect(() => {

--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -13,6 +13,7 @@ import { LivePhotoContext } from '../Context/LivePhoto';
 import { ScoreContext } from '../Context/Score';
 import { Column } from '../Layout';
 import ImageCard from './ImageCard';
+import { sendToElectronStore } from '../../helpers/ipcMainEvents';
 
 const LiveImage = ({ cameraId }) => {
   const { setLivePhotoContext } = useContext(LivePhotoContext);
@@ -37,6 +38,7 @@ const LiveImage = ({ cameraId }) => {
     if (isBadQuality) {
       setTimeout(() => estimate(), 50);
     } else {
+      sendToElectronStore('Livephoto', 'Taken');
       videoRef.current.pause();
       setShowCanvas(true);
       setShowVideo(false);
@@ -51,6 +53,7 @@ const LiveImage = ({ cameraId }) => {
       estimate();
     });
     setScoreContext({});
+    sendToElectronStore('Livephoto', 'Initialised');
   }, []);
 
   return (

--- a/packages/react/src/helpers/common.js
+++ b/packages/react/src/helpers/common.js
@@ -1,3 +1,5 @@
+import crypto from 'crypto';
+
 export const isEmpty = (object) => {
   if (!object) return true;
 
@@ -10,5 +12,7 @@ export const post = (url, data) =>
     body: JSON.stringify(data),
     headers: { 'Content-Type': 'application/json' },
   }).then((response) => response.text());
+
+export const generateUUID = () => crypto.randomBytes(16).toString('hex');
 
 export default {};

--- a/packages/react/src/helpers/globalError.js
+++ b/packages/react/src/helpers/globalError.js
@@ -1,0 +1,5 @@
+import { sendToElectronStore } from './ipcMainEvents';
+
+window.onerror = (message, source, lineno, colno, error) => {
+  sendToElectronStore('reactError', { message, source, lineno, colno, error });
+};

--- a/packages/react/src/helpers/ipcMainEvents.js
+++ b/packages/react/src/helpers/ipcMainEvents.js
@@ -9,7 +9,9 @@ const { ipcRenderer } = electron;
 })();
 
 export const sendToElectronStore = (key, value) => {
-  ipcRenderer.invoke('addToStore', key, value);
+  const strKey = typeof key === 'object' ? JSON.stringify(key) : key;
+  const strValue = typeof value === 'object' ? JSON.stringify(value) : value;
+  ipcRenderer.invoke('addToStore', strKey, strValue);
 };
 
 export default {};


### PR DESCRIPTION
## Description

Adding more logs to bothe React & Electron
- Global React error log
- Global Electron error log
- Live photo log event
- Electron on start & close event

## Testing
- `npm i && npm run dev` or `npm i && npm build`
- Run the application
- All actions from the list in ticket [COP-3063](https://support.cop.homeoffice.gov.uk/browse/COP-3063) should be logged to the log file


### Log file should be in
**Mac OS:** ~/Library/Application Support/IDE/ide-controller.db
**Windows:** C:\Users\<you>\AppData\Local\IDE\ide-controller.db
**Linux:** ~/.config/IDE/ide-controller.db



## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
