### PR TITLE
COP-3254 Set fullscreen window on build

### DIFF
--- a/packages/electron/main.js
+++ b/packages/electron/main.js
@@ -49,6 +49,7 @@ function createWindow() {
   if (isDev) {
     mainWindow.loadURL('http://localhost:3000');
   } else {
+    mainWindow.setFullScreen(true);
     mainWindow.loadFile(path.resolve(__dirname, '../react/build/index.html'));
   }
 


### PR DESCRIPTION
## Description

This PR is to make IDE Controller start with full screen on production

## Testing 

- `npm i && npm build`
- Run the application from `/packages/electron/dist/mac/IDE`

### Expected results
- The app should start in full screen



## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
