### PR TITLE
3- COP-3279 Fix data read table

### DIFF
--- a/packages/react/src/Components/Molecules/DataReadTable.jsx
+++ b/packages/react/src/Components/Molecules/DataReadTable.jsx
@@ -4,7 +4,10 @@ import React, { useContext, useEffect, useState } from 'react';
 // Local imports
 import TableRow from './TableRow';
 import { EventSourceContext } from '../Context/EventSource';
-import { END_OF_DOCUMENT_DATA } from '../../config/EventSource';
+import {
+  END_OF_DOCUMENT_DATA,
+  START_OF_DOCUMENT_DATA,
+} from '../../config/EventSource';
 
 const tagStatusMap = {
   successful: 'passed',
@@ -43,6 +46,15 @@ const DataReadTable = () => {
       updateChipText();
     }
   }, [eventSourceEvent, didFinishScan]);
+
+  useEffect(() => {
+    const newScanTriggered = eventSourceEvent === START_OF_DOCUMENT_DATA;
+    const clearDataButtonTriggered = eventSourceEvent?.startsWith('RESTART');
+    if (newScanTriggered || clearDataButtonTriggered) {
+      setMRZTagText('No data');
+      setChipTagText('No data');
+    }
+  }, [eventSourceEvent]);
 
   return (
     <table className="govuk-table font--19pt">


### PR DESCRIPTION
## Description
This branch fixes a display bug that causes the status tag in the Data read table to display with the warning colour when the clear data immediately button is pressed. 

## To test
- pull branch and run command `npm ci && npm run dev`
- deploy to test machine
- scan document
- hit the "Clear data immediately" button
- the status tags in the "Data read" table should display in grey with the text "NO DATA" 

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
