### PR TITLE
4- COP-3276 Fix camera tak picture too quickly

### DIFF
--- a/packages/react/src/Components/Molecules/LiveImage.jsx
+++ b/packages/react/src/Components/Molecules/LiveImage.jsx
@@ -51,7 +51,7 @@ const LiveImage = ({ cameraId }) => {
 
   useEffect(() => {
     videoRef.current.addEventListener('canplay', async () => {
-      estimate();
+      setTimeout(estimate, 1000);
     });
     setScoreContext({});
     sendToElectronStore('Livephoto', 'Initialised');


### PR DESCRIPTION
## Description
Branch adds a short 1s delay between the camera switching on and the system capturing the image. This fixes the bug that sees the software taking pictures too quickly, resulting in a low brightness image. 

## To test
- pull branch and run command `npm ci && npm run build`
- deploy build to dev machine
- run app and allow to take pictures of you
- there should be at least a 1s delay between tapping the "Retake camera image" button, and the system capturing a new image. 

## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
