### PR TITLE
Empty image context when scan new doc event fired

### DIFF
--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -49,6 +49,7 @@ const App = () => {
       }
       sendToElectronStore(messageData.event, messageData);
       if (messageData.event === START_OF_DOCUMENT_DATA) {
+        setLivePhotoContext({});
         setEventSourceContext({
           timestamp: Date.now(),
           eventSourceEvent: START_OF_DOCUMENT_DATA,
@@ -82,8 +83,8 @@ const App = () => {
   }, []);
 
   const { CD_IMAGEPHOTO, CD_SCDG2_PHOTO } = eventSourceContext;
+  const { image } = livePhotoContext;
   useEffect(() => {
-    const { image } = livePhotoContext;
     if (!CD_IMAGEPHOTO?.image || !image) return;
 
     post(IMAGE_MATCH, {
@@ -100,7 +101,7 @@ const App = () => {
           match: { score: 0 },
         })
       );
-  }, [livePhotoContext?.image, CD_IMAGEPHOTO, CD_SCDG2_PHOTO]);
+  }, [image, CD_IMAGEPHOTO, CD_SCDG2_PHOTO]);
 
   return (
     <EventSourceProvider

--- a/packages/react/src/App.jsx
+++ b/packages/react/src/App.jsx
@@ -38,7 +38,8 @@ const App = () => {
         codelineData: messageData.codelineData,
         image: messageData.image,
       };
-      sendToElectronStore(eventSourceData[datatype], datadata);
+      if (eventSourceData[datatype])
+        sendToElectronStore(eventSourceData[datatype], datadata);
       eventSourceData[datatype] = datadata;
     });
 
@@ -47,7 +48,8 @@ const App = () => {
       if (messageData.event) {
         eventSourceData[messageData.event] = messageData;
       }
-      sendToElectronStore(messageData.event, messageData);
+      if (messageData.event)
+        sendToElectronStore(messageData.event, messageData);
       if (messageData.event === START_OF_DOCUMENT_DATA) {
         setLivePhotoContext({});
         setEventSourceContext({


### PR DESCRIPTION
## Description

Fix score not updated when `Clear data` button clicked

## Testing
- `npm i && npm run dev` or `npm i && npm build`
- Run the application
- Allow the camera to take pictures
- Scan a document
- Click `Clear data` button but don't let the camera take new picture
- Scan a document

### Expected results

- The `Image likeness` should be  `No data`
- Then if you allow the camera to take picture it should update

## Developer Checklist

\* Required

- [ ] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
