### PR TITLE
Allow installation file to be in program file

### DIFF
--- a/packages/electron/electron-builder.js
+++ b/packages/electron/electron-builder.js
@@ -26,5 +26,8 @@ module.exports = {
     installerIcon: 'build/icon.ico',
     uninstallerIcon: 'build/icon.ico',
     runAfterFinish: 'false',
+    oneClick: false,
+    allowToChangeInstallationDirectory: true,
+    perMachine: true,
   },
 };


### PR DESCRIPTION
## Description

In this PR an option passed to `electron-builder` that gives the user the ability to select installation location

## Testing
- `npm i && npm run dev` or `npm i && npm build`
- Run the executable file from windows

### Expected results
- Installation should default to `C:\Program Files\IDE`


## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [ ] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
