### PR TITLE
COP-4596 Add scan duration

### DIFF
--- a/packages/react/src/helpers/log.js
+++ b/packages/react/src/helpers/log.js
@@ -1,6 +1,10 @@
 // Local imports
 import { sendToElectronStore } from './ipcMainEvents';
 import { sha256hash } from './common';
+import {
+  END_OF_DOCUMENT_DATA,
+  START_OF_DOCUMENT_DATA,
+} from '../config/EventSource';
 
 const ALLOWED_KEYS = [
   'DateOfBirth',
@@ -12,6 +16,7 @@ const ALLOWED_KEYS = [
 ];
 
 let currentData = {};
+let documentStartEventTimestamp;
 
 const resetCurrentData = () => {
   currentData = {
@@ -51,6 +56,12 @@ export const logDataEvent = (key, data) => {
       currentData.uuid = data;
       break;
     case 'PAGE_READER_EVENT':
+      if (data.event === START_OF_DOCUMENT_DATA) {
+        documentStartEventTimestamp = Date.now();
+      } else if (data.event === END_OF_DOCUMENT_DATA) {
+        currentData.scanDuration =
+          (Date.now() - documentStartEventTimestamp) / 1000;
+      }
       currentData.PAGE_READER_EVENT.push(data.event);
       break;
     case 'CD_IMAGEIR':

--- a/packages/react/src/helpers/log.js
+++ b/packages/react/src/helpers/log.js
@@ -81,6 +81,8 @@ export const logDataEvent = (key, data) => {
       break;
     case 'matchingScore':
       currentData.matchingScore = data;
+      currentData.scanToScoreDuration =
+        (Date.now() - documentStartEventTimestamp) / 1000;
       sendToElectronStore(currentData);
       resetCurrentData();
       break;


### PR DESCRIPTION
https://support.cop.homeoffice.gov.uk/browse/COP-4569

## Description
Add scan & scanToScore duration in seconds to log


## Test
1. `npm run build`
2. Install the application on windows machine
3. Scan a document
4. Take photo
5. Login to Azure Monitor and look at the latest logs

## Expected Results
You should see both scanDuration & scanToScoreDuration in the log data

![image](https://user-images.githubusercontent.com/30794075/103951201-2a053400-5136-11eb-924a-6774e06eef42.png)



## Developer Checklist

\* Required

- [x] Up-to-date with master branch? \*

- [ ] Does it have tests?

- [x] Pull request URL linked to JIRA ticket? \*

- [ ] All reviewer comments resolved/answered? \*
